### PR TITLE
Add default column values to Model mapping

### DIFF
--- a/src/elements/Form.php
+++ b/src/elements/Form.php
@@ -45,13 +45,13 @@ class Form extends Element
     public $saveAsNew;
     public $fieldLayoutId;
     public $titleFormat;
-    public $displaySectionTitles;
+    public $displaySectionTitles = false;
     public $redirectUri;
     public $submitAction;
     public $submitButtonText;
-    public $saveData;
+    public $saveData = false;
     public $templateOverridesFolder;
-    public $enableFileAttachments;
+    public $enableFileAttachments = false;
 
     /**
      * @inheritdoc


### PR DESCRIPTION
I have been receiving a DB Integrity Violation Exception every time I create a new Form in the CP.  After a bit of researching I found that the createNewForm() method in \barrelstrength\sproutforms\services\Forms creates a new \barrelstrength\sproutforms\elements\Form model and while it does set the initial values for $name, $handle, it was currently not setting any default values for $displaySectionTitles, $enableFileAttachments and $saveData. All of these three attributes are defined as NOT nullable in the %{sproutforms_forms} DB column. This results in an INSERT query where the values for these columns is set as NULL and results in the above mentioned exception. 

I have added the default values to these attributes within the model itself so it reflects the default state as in its respective DB column. This also conforms to Craft coding guidelines.

Please let me know if any modifications are required.

Thanks!