### PR TITLE
Better OnBeforeSaveEntryEvent validation check before saving an entry, because $event->isValid could be overridden, but the $event->errors array won't.

### DIFF
--- a/src/services/Entries.php
+++ b/src/services/Entries.php
@@ -293,7 +293,7 @@ class Entries extends Component
         $transaction = $db->beginTransaction();
 
         try {
-            if (!$event->isValid) {
+            if (!$event->isValid or !empty($event->errors)) {
                 foreach ($event->errors as $key => $error) {
                     $entry->addError($key, $error);
                 }


### PR DESCRIPTION
Hi Ben,

I'm trying to do something in a custom OnBeforeSaveEntryEvent handler, and want to prevent the rest of the entry saving code from executing as well as navigate users back to the form page with custom error messages displayed when necessary.

You may have seen me seeking for a solution in this post https://github.com/barrelstrength/craft-sprout-forms/issues/241. I was trying to hack it a little bit by setting $event->isValid to false. Then I realised this variable is overridden by the Google ReCaptcha for SproutForms plugin later on while Craft looping through the handlers.

Now, I believe the best option is to add an additional param to the OnBeforeSaveEntryEvent class, something like my changes suggest.

Would appreciate if you can consider pulling or suggest a better solution.

Cheers,
Wei