### PR TITLE
Fixed status filter

### DIFF
--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -178,8 +178,11 @@ class Entry extends Element
         $statusArray = [];
 
         foreach ($statuses as $status) {
-            $key = $status['handle'].' '.$status['color'];
-            $statusArray[$key] = $status['name'];
+            $key = $status['handle'];
+            $statusArray[$key] = [
+                'label' => $status['name'],
+                'color' => $status['color'],
+            ];
         }
 
         return $statusArray;

--- a/src/elements/db/EntryQuery.php
+++ b/src/elements/db/EntryQuery.php
@@ -186,8 +186,9 @@ class EntryQuery extends ElementQuery
             'sproutforms_entrystatuses.handle as statusHandle'
         ]);
 
-        $this->query->innerJoin('{{%sproutforms_entrystatuses}} sproutforms_entrystatuses', '[[sproutforms_entrystatuses.id]] = [[sproutforms_entries.statusId]]');
         $this->query->innerJoin('{{%sproutforms_forms}} sproutforms_forms', '[[sproutforms_forms.id]] = [[sproutforms_entries.formId]]');
+        $this->query->innerJoin('{{%sproutforms_entrystatuses}} sproutforms_entrystatuses', '[[sproutforms_entrystatuses.id]] = [[sproutforms_entries.statusId]]');
+        $this->subQuery->innerJoin('{{%sproutforms_entrystatuses}} sproutforms_entrystatuses', '[[sproutforms_entrystatuses.id]] = [[sproutforms_entries.statusId]]');
 
         if ($this->formId) {
             $this->subQuery->andWhere(Db::parseParam(
@@ -214,7 +215,7 @@ class EntryQuery extends ElementQuery
         }
 
         if ($this->statusHandle) {
-            $this->query->andWhere(Db::parseParam(
+            $this->subQuery->andWhere(Db::parseParam(
                 'sproutforms_entrystatuses.handle', $this->statusHandle)
             );
         }
@@ -226,6 +227,15 @@ class EntryQuery extends ElementQuery
         }
 
         return parent::beforePrepare();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function statusCondition(string $status)
+    {
+        return Db::parseParam(
+            'sproutforms_entrystatuses.handle', $status);
     }
 
     /**

--- a/src/elements/db/EntryQuery.php
+++ b/src/elements/db/EntryQuery.php
@@ -3,6 +3,7 @@
 namespace barrelstrength\sproutforms\elements\db;
 
 use barrelstrength\sproutforms\elements\Form;
+use craft\base\Element;
 use craft\db\Query;
 use craft\elements\db\ElementQuery;
 use craft\helpers\Db;
@@ -234,8 +235,21 @@ class EntryQuery extends ElementQuery
      */
     protected function statusCondition(string $status)
     {
-        return Db::parseParam(
-            'sproutforms_entrystatuses.handle', $status);
+        switch ($status) {
+            case Element::STATUS_ENABLED:
+                return ['elements.enabled' => true];
+            case Element::STATUS_DISABLED:
+                return ['elements.enabled' => false];
+            case Element::STATUS_ARCHIVED:
+                return ['elements.archived' => true];
+            default:
+                if (!empty($status)) {
+                    return Db::parseParam(
+                        'sproutforms_entrystatuses.handle', $status);
+                }
+        }
+
+        return false;
     }
 
     /**

--- a/src/templates/entries/_edit.twig
+++ b/src/templates/entries/_edit.twig
@@ -81,6 +81,8 @@
 
     </div>
 
+    {% hook 'cp.sproutForms.entries.edit.content' %}
+
 {% endblock %}
 
 {% block details %}
@@ -148,6 +150,8 @@
             {% endfor %}
         </div>
     {% endif %}
+
+    {% hook 'cp.sproutForms.entries.edit.details' %}
 {% endblock %}
 
 {% css %}

--- a/src/templates/forms/_editForm.twig
+++ b/src/templates/forms/_editForm.twig
@@ -90,11 +90,15 @@
 
         <div id="deletedFieldsContainer" class="hidden"></div>
 
+        {% hook 'cp.auctions.forms.edit.content' %}
+
     </div>
 {% endblock %}
 
 {% block details %}
     {% include 'sprout-forms/forms/_sidebar/settings' %}
+
+    {% hook 'cp.auctions.forms.edit.details' %}
 {% endblock %}
 
 {% do view.registerAssetBundle("barrelstrength\\sproutbase\\web\\assets\\cp\\CpAsset") %}


### PR DESCRIPTION
The entry status filter on the entry element index page doesn't work due to searching the `status` criteria. This fixes that and also fixes the status colour which was causing additional issues.

I've also added some template hooks, I hope you'll consider adding those.