### PR TITLE
Remove code that removes the escaping on hyphens in the RegEx

### DIFF
--- a/src/fields/formfields/RegularExpression.php
+++ b/src/fields/formfields/RegularExpression.php
@@ -133,9 +133,6 @@ class RegularExpression extends FormField implements PreviewableFieldInterface
 
         $pattern = $this->customPattern;
 
-        // Do no escape "-" html5 does not treat it as special chars
-        $pattern = str_replace("\\-", '-', $pattern);
-
         $rendered = Craft::$app->getView()->renderTemplate('regularexpression/input',
             [
                 'name' => $this->handle,


### PR DESCRIPTION
* Firstly because `-` needs escaping in Javascript Regexes
* Secondly because extra escaping actually does no harm.

This should Fix #465 