### PR TITLE
Add delimiter option for datasource export

### DIFF
--- a/src/integrations/sproutreports/datasources/EntriesDataSource.php
+++ b/src/integrations/sproutreports/datasources/EntriesDataSource.php
@@ -35,6 +35,9 @@ use Twig\Error\SyntaxError;
  */
 class EntriesDataSource extends DataSource
 {
+    const DELIMITER_COMMA = ',';
+    const DELIMITER_SEMICOLON = ';';
+    
     /**
      * @return string
      */
@@ -227,6 +230,17 @@ class EntriesDataSource extends DataSource
             ];
         }
 
+        $delimiterOptions = [
+            [
+                'label' => Craft::t('sprout-forms', 'Comma seperated'),
+                'value' => self::DELIMITER_COMMA,
+            ],
+            [
+                'label' => Craft::t('sprout-forms', 'Semicolon seperated'),
+                'value' => self::DELIMITER_SEMICOLON,
+            ],
+        ];
+
         // @todo Determine sensible default start and end date based on Order data
         $defaultStartDate = null;
         $defaultEndDate = null;
@@ -269,7 +283,9 @@ class EntriesDataSource extends DataSource
             'dateRanges' => $dateRanges,
             'options' => $settings,
             'entryStatusOptions' => $entryStatusOptions,
-            'defaultSelectedEntryStatuses' => $defaultSelectedEntryStatuses
+            'defaultSelectedEntryStatuses' => $defaultSelectedEntryStatuses,
+            'delimiter' => $settings['delimiter'],
+            'delimiterOptions' => $delimiterOptions,
         ]);
     }
 

--- a/src/templates/_integrations/sproutreports/datasources/EntriesDataSource/settings.twig
+++ b/src/templates/_integrations/sproutreports/datasources/EntriesDataSource/settings.twig
@@ -49,6 +49,15 @@
         options: entryStatusOptions,
         values: options.entryStatusIds is defined ? options.entryStatusIds : defaultSelectedEntryStatuses
     }) }}
+	
+	{{ forms.selectField({
+		label: "Delimiter"|t('sprout-forms'),
+		instructions: 'Select which delimiter to use in the export.'|t('sprout-forms'),
+		name: 'settings[delimiter]',
+		options: delimiterOptions,
+		value: options.delimiter,
+		first: true
+	}) }}
 {% else %}
 
     {% set boxBody %}


### PR DESCRIPTION
When exporting results from a datasource to CSV the delimiter is set to *,* by default. Some OS have another delimiter (e.g. *;*) set as default delimiter for CSV - files. By adding a delimiter option to the report users can choose which delimiter should be used when making an export.

For existing reports the default (*,*) delimiter is used.

Also see [this PR](https://github.com/barrelstrength/craft-sprout-base-reports/pull/6).