### PR TITLE
fix: correct position of quote mark in multiplechoice

### DIFF
--- a/src/templates/_components/formtemplates/accessible/fields/multiplechoice/input.twig
+++ b/src/templates/_components/formtemplates/accessible/fields/multiplechoice/input.twig
@@ -18,7 +18,7 @@
 {% spaceless %}
     <div
         {%- if id %} id="{{ id }}"{% endif %}
-        {%- if class %} class="{{ class }}{% endif %}">
+        {%- if class %} class="{{ class }}"{% endif %}>
 
         {%- for key, option in options %}
 


### PR DESCRIPTION
End quote mark of class attribute is outside the if condition so when there is no class the template breaks.