### PR TITLE
Fix 

### DIFF
--- a/src/elements/Form.php
+++ b/src/elements/Form.php
@@ -178,7 +178,7 @@ class Form extends Element
     protected static function defineSortOptions(): array
     {
         $attributes = [
-            'name' => Craft::t('sprout-forms', 'Form Name'),
+            'sproutforms_forms.name' => Craft::t('sprout-forms', 'Form Name'),
             'elements.dateCreated' => Craft::t('sprout-forms', 'Date Created'),
             'elements.dateUpdated' => Craft::t('sprout-forms', 'Date Updated'),
         ];


### PR DESCRIPTION
Craft 3.6.3 throws the following error when trying to view the Forms index:

```
PDOException: SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'name' in order clause is ambiguous in /site/vendor/yiisoft/yii2/db/Command.php:1299
```

Fixes https://github.com/barrelstrength/craft-sprout-forms/issues/558