### PR TITLE
Fix TypeError with file upload field and null defaultUploadLocationSubpath plugin setting

### DIFF
--- a/src/fields/formfields/FileUpload.php
+++ b/src/fields/formfields/FileUpload.php
@@ -58,7 +58,7 @@ class FileUpload extends CraftAssets
 
         if (!$this->singleUploadLocationSubpath) {
             $settings = SproutForms::$app->getSettings();
-            $this->singleUploadLocationSubpath = $settings->defaultUploadLocationSubpath;
+            $this->singleUploadLocationSubpath = $settings->defaultUploadLocationSubpath ?? '';
         }
     }
 

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -56,7 +56,7 @@ class Settings extends Model implements SproutSettingsInterface
 
     public $allowedAssetVolumes = '*';
 
-    public $defaultUploadLocationSubpath = null;
+    public $defaultUploadLocationSubpath = '';
 
     /**
      * @inheritdoc


### PR DESCRIPTION
This pull request fixes a bug in Sprout Forms 3.13.16, where if a file upload field doesn't have an upload subpath set, and the plugin's default upload subpath isn't set, trying to view a form submission entry causes the error:

`craft\fields\Assets::_resolveVolumePathToFolderId(): Argument #2 ($subpath) must be of type string, null given, called in /var/www/html/vendor/craftcms/cms/src/fields/Assets.php on line 935`

This is due to the new plugin setting `defaultUploadLocationSubpath` defaulting to `null` rather than an empty string, which this pull request changes. This pull request also amends the file upload class constructor to fall back to an empty string if `$settings->defaultUploadLocationSubpath` is `null`, which seems to still be the case if the `null`-ness of `defaultUploadLocationSubpath` has been saved in the project config (which was the case for me while testing this).

### Steps to reproduce

- Have Sprout Forms 3.13.15 installed, with a form that has a file upload field with no upload subpath set
- Make a form submission with an attachment
- Update to 3.15.16
- Try to view the form submission in the Craft control panel
- Get the above-described TypeError

### Additional info

- Craft version: 3.7.67
- PHP version: 8.1.11
- Database driver & version: MySQL 10.4.26
